### PR TITLE
Bugfix regarding issue #77: Fixed default argument on /board command

### DIFF
--- a/KanbanCord.Bot/Commands/BoardCommand.cs
+++ b/KanbanCord.Bot/Commands/BoardCommand.cs
@@ -21,11 +21,11 @@ public class BoardCommand
 
     [Command("board")]
     [Description("Displays a given column on the board.")]
-    public async ValueTask ExecuteAsync(SlashCommandContext context, [Description("The column to show")] [SlashChoiceProvider<ColumnChoiceProvider>] int column = 0)
+    public async ValueTask ExecuteAsync(SlashCommandContext context, [Description("The column to show")] [SlashChoiceProvider<ColumnChoiceProvider>] int? column = null)
     {
         var boardItems = await _repository.GetAllTaskItemsByGuildIdAsync(context.Guild!.Id);
 
-        var boardStatus = (BoardStatus)column;
+        var boardStatus = (BoardStatus?)column;
         
         var embed = await BoardHelper.GetBoardEmbed(context.Client, boardItems, boardStatus);
         


### PR DESCRIPTION
This update fixed the default value in `/board` from being set to 0 (which corresponds to the first element of the Enum), to `null`.

After carefully looking through the code, the logic further behind this file is made to work with this `null` value as default to show all columns. I have further tested this on a local Docker container with temporary bot & token, the results are successful, as shown below:
<img width="1532" height="994" alt="image" src="https://github.com/user-attachments/assets/5590a579-ba87-4e47-b6d4-23c9b0b182a8" />
